### PR TITLE
Support for adding items after plugin was initialised

### DIFF
--- a/jquery.lazy.js
+++ b/jquery.lazy.js
@@ -128,7 +128,7 @@
                 };
 
                 event.addItems = function(event){
-                    items = event.items;
+                    _addItems(event.items);
                 };
 
                 // bind lazy load functions to scroll and resize event
@@ -262,14 +262,14 @@
          * @param {array} items
          * @return void
          */
-        function addItems(newItems)
+        function _addItems(newItems)
         {
             if( configuration("defaultImage") !== null || configuration("placeholder") !== null )
-                for( var i = 0; i < items.length; i++ )
+                for( var i = 0; i < newItems.length; i++ )
                 {
-                    _addItemPlaceHolder(items[i]);
+                    _addItemPlaceHolder(newItems[i]);
                 }
-            _items.push.apply(_items, newItems);
+            items.push.apply(items, newItems);
         }
 
 
@@ -577,6 +577,7 @@
         _instance.addItems = function(newItems)
         {
             _event.addItems({items: newItems});
+            return _instance;
         };
 
         /**


### PR DESCRIPTION
Changes made to support adding content dynamically after initial loading

1. refactored the placeholder logic out to a separate function so it can be re-used
2. the plugin would automatically remove itself once the queue was empty, I have made this an option AutoDestroy
3. added customLoader and customerLoader options to delegate loading for non image content, aka DIVs with attributes which can be passed back to an application to render out HTML
4. instance.addItems() which allows passing in a jquery selection to be lazy loaded
5. instance.show() which triggers loading (for some reason update() overwrites items)
6. instance.configure() allows changing configuration options, for example, setting autoDestroy to true once you have finished adding additional items to the loading queue