### PR TITLE
Refactored the access of the window height and width.

### DIFF
--- a/jquery.lazy.js
+++ b/jquery.lazy.js
@@ -501,7 +501,9 @@
          * @return {number}
          */
         function _getActualWidth() {
-            return _actualWidth >= 0 ? _actualWidth : (_actualWidth = $(window).width());
+            return _actualWidth >= 0 ? _actualWidth : (_actualWidth = window.innerWidth
+                || document.documentElement.clientWidth
+                || document.body.clientWidth);
         }
 
         /**
@@ -510,7 +512,9 @@
          * @return {number}
          */
         function _getActualHeight() {
-            return _actualHeight >= 0 ? _actualHeight : (_actualHeight = $(window).height());
+            return _actualHeight >= 0 ? _actualHeight : (_actualHeight = window.innerHeight
+                || document.documentElement.clientHeight
+                || document.body.clientHeight);
         }
 
         /**


### PR DESCRIPTION
While we were working with jQuery.lazy we were facing an issue which was caused by a wrong calculation of the window height and width. In our case the method returned a value which was multiple times as high as the real window size was. Due to this issue all component were initialized and not only these ones in the visible area and the threshold.

We figured out that this is a known issue:
http://stackoverflow.com/questions/10569301/why-is-window-height-so-wrong

To solve the issue we switched from ```$(window).width()``` to ```window.innerWidth```. To stay compatible to Internet Explorer versions older then 9 we check further attributes ```window.innerHeight + || document.documentElement.clientHeight + || document.body.clientHeight``` to get the height in all cases.
For the window width the same changes were applied.

The issues was initially discovered in:
- OS X El Capitan
- Firefox 46
- Chrome 

I would appriciate if you could incorporate our pull request and apply it to the minimized version as well.