### PR TITLE
add main script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "title": "jQuery & Zepto Lazy - Delayed Content, Image and Background Loader",
   "version": "1.7.1",
   "description": "Lazy is a fast, feature-rich and lightweight delayed content loading plugin for jQuery and Zepto. It's designed to speed up page loading times and decrease traffic to your users by only loading the content in view.",
+  "main": "jquery.lazy.js",
   "homepage": "http://jquery.eisbehr.de/lazy/",
   "bugs": "http://github.com/eisbehr-/jquery.lazy/issues",
   "author": {


### PR DESCRIPTION
People using npm need to have a main field in the `package.json` to make it work as expected.