### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Some examples below:
 Lazy and all plugins are available over [cdnjs](http://cdnjs.com) and [jsDelivr](http://jsdelivr.com) CDN and can directly included to every page.
 ```HTML
 <!-- jsDeliver -->
-<script type="text/javascript" src="//cdn.jsdelivr.net/jquery.lazy/1.7.5/jquery.lazy.min.js"></script>
-<script type="text/javascript" src="//cdn.jsdelivr.net/jquery.lazy/1.7.5/jquery.lazy.plugins.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/jquery-lazy@1.7.5/jquery.lazy.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/jquery-lazy@1.7.5/jquery.lazy.plugins.min.js"></script>
 
 <!-- cdnjs -->
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.5/jquery.lazy.min.js"></script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.
I updated the links now so you don't forget to do it when you release a new version.
I also noticed the same links are at http://jquery.eisbehr.de/lazy/, might be a good idea to update those.

Feel free to ping me if you have any questions regarding this change.