### PR TITLE
Disable loading if hidden

### DIFF
--- a/jquery.lazy.js
+++ b/jquery.lazy.js
@@ -526,6 +526,9 @@
          * @return {boolean}
          */
         function _isInLoadableArea(element) {
+            if (window.getComputedStyle(element).display === "none") {
+                return false;
+            }
             var elementBound = element.getBoundingClientRect(),
                 direction    = config.scrollDirection,
                 threshold    = config.threshold,


### PR DESCRIPTION
For me, jquery.lazy always loaded images even if they currently are not visible. This checks if the image is visible (i.e. display != none) before calculating if the image is in the viewport.
I thought you might find this helpful.